### PR TITLE
Fix API timeout issues by improving connection pooling

### DIFF
--- a/internal/api.go
+++ b/internal/api.go
@@ -30,7 +30,13 @@ type HTTPClient struct {
 func NewHTTPClient(apiKey, organizationId, baseURL string) *HTTPClient {
 	return &HTTPClient{
 		client: &http.Client{
-			Timeout: 30 * time.Second, // 30 second timeout is reasonable for most API calls
+			Transport: &http.Transport{
+				MaxConnsPerHost:     12,  // Allow 12 concurrent connections per host (slightly above Terraform's default parallelism of 10)
+				MaxIdleConns:        100, // Maximum idle connections across all hosts
+				MaxIdleConnsPerHost: 12,  // Maximum idle connections per host
+				IdleConnTimeout:     90 * time.Second,
+			},
+			Timeout: 90 * time.Second,
 		},
 		baseURL:        baseURL,
 		apiKey:         apiKey,


### PR DESCRIPTION
## Problem
Users were experiencing frequent timeout errors when running `terraform apply`, requiring multiple retries to succeed. The errors showed "context deadline exceeded" even though individual API requests only took at most ~5 seconds.

## Solution
- Increased HTTP client connection limits from default 2 to 12 concurrent connections per host
- Increased timeout from 30s to 90s to provide additional buffer
- Added explicit connection pooling configuration to prevent request queuing

## Root Cause
The default Go HTTP client only allows 2 concurrent connections per host. When Terraform runs with its default parallelism of 10, requests were queuing for available connections and hitting the 30-second timeout while waiting.


In my testing, I'm able to create/destroy 30 usage groups without timeouts using this version