### PR TITLE
TF apply bundles usage group changes into a new version in SELECT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ setup-dev-overrides:
 	@echo "Dev overrides configured in ~/.terraform.d/.terraformrc"
 	cat ~/.terraform.d/.terraformrc
 	cp ~/.terraform.d/.terraformrc ./.terraformrc
+	cp ~/.terraform.d/.terraformrc ~/.terraformrc
 
 
 # Testing targets

--- a/internal/api.go
+++ b/internal/api.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// HTTPClient wraps the standard http.Client with configuration
 type HTTPClient struct {
 	client         *http.Client
 	baseURL        string
@@ -27,8 +26,6 @@ type HTTPClient struct {
 	organizationId string
 }
 
-// NewHTTPClient creates a new HTTP client with reasonable defaults
-// Best practice: Centralize client creation with consistent timeouts and configuration
 func NewHTTPClient(apiKey, organizationId, baseURL string) *HTTPClient {
 	return &HTTPClient{
 		client: &http.Client{
@@ -46,28 +43,22 @@ func NewHTTPClient(apiKey, organizationId, baseURL string) *HTTPClient {
 	}
 }
 
-// buildURL constructs the full URL for API calls
 func (c *HTTPClient) buildURL(endpoint string) string {
 	return fmt.Sprintf("%s%s", c.baseURL, endpoint)
 }
 
-// makeRequest is a low-level method that handles the basic HTTP request/response cycle
-// Best practice: Centralize HTTP request logic to avoid code duplication
 func (c *HTTPClient) makeRequest(ctx context.Context, method, endpoint string, body io.Reader) (*http.Response, error) {
 	url := c.buildURL(endpoint)
 
-	// Create request with context for proper cancellation
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err
 	}
 
-	// Set content type for JSON requests
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiKey))
-	// Make the request
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -76,8 +67,6 @@ func (c *HTTPClient) makeRequest(ctx context.Context, method, endpoint string, b
 	return resp, nil
 }
 
-// readResponseBody reads and returns the response body as a string
-// Best practice: Centralize response reading to handle errors consistently
 func readResponseBody(resp *http.Response) (string, error) {
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -86,22 +75,18 @@ func readResponseBody(resp *http.Response) (string, error) {
 	return string(body), nil
 }
 
-// handleHTTPError creates a diagnostic error for HTTP failures
-// Best practice: Standardize error messages across the provider
 func handleHTTPError(operation string, err error) diag.Diagnostics {
 	return diag.Diagnostics{
 		diag.NewErrorDiagnostic("HTTP Request Error", fmt.Sprintf("Failed to %s: %v", operation, err)),
 	}
 }
 
-// handleResponseError creates a diagnostic error for API response failures
 func handleResponseError(operation string, statusCode int, body string) diag.Diagnostics {
 	return diag.Diagnostics{
 		diag.NewErrorDiagnostic("API Error", fmt.Sprintf("API returned status %d during %s: %s", statusCode, operation, body)),
 	}
 }
 
-// handleJSONError creates a diagnostic error for JSON parsing failures
 func handleJSONError(operation string, err error) diag.Diagnostics {
 	return diag.Diagnostics{
 		diag.NewErrorDiagnostic("JSON Error", fmt.Sprintf("Failed to parse JSON during %s: %v", operation, err)),
@@ -176,23 +161,18 @@ func convertTerraformToAPI(src interface{}) interface{} {
 			field := srcType.Field(i)
 			fieldValue := srcValue.Field(i)
 
-			// Skip unexported fields
 			if !fieldValue.CanInterface() {
 				continue
 			}
 
-			// Get JSON tag for field name
 			jsonTag := field.Tag.Get("json")
 			if jsonTag == "" || jsonTag == "-" {
-				// Use tfsdk tag if no json tag
 				jsonTag = field.Tag.Get("tfsdk")
 			}
 			if jsonTag == "" {
-				// Use field name if no tags
 				jsonTag = field.Name
 			}
 
-			// Remove omitempty and other options from tag
 			if commaIdx := len(jsonTag); commaIdx > 0 {
 				for j, char := range jsonTag {
 					if char == ',' {
@@ -203,10 +183,8 @@ func convertTerraformToAPI(src interface{}) interface{} {
 				jsonTag = jsonTag[:commaIdx]
 			}
 
-			// Convert the field value
 			convertedValue := convertTerraformToAPI(fieldValue.Interface())
 
-			// Only include non-nil values to avoid sending empty fields
 			if convertedValue != nil {
 				result[jsonTag] = convertedValue
 			}
@@ -215,29 +193,25 @@ func convertTerraformToAPI(src interface{}) interface{} {
 		return result
 	}
 
-	// Return the value as-is for basic types
 	return srcValue.Interface()
 }
 
 // normalizeJSON normalizes a JSON string to ensure consistent key ordering
 func normalizeJSON(jsonStr string) (string, error) {
-	// Parse the JSON string
 	var jsonObj interface{}
 	if err := json.Unmarshal([]byte(jsonStr), &jsonObj); err != nil {
-		return jsonStr, err // Return original string if parsing fails
+		return jsonStr, err
 	}
 
-	// Re-encode with sorted keys to ensure consistent ordering
 	normalized, err := json.Marshal(jsonObj)
 	if err != nil {
-		return jsonStr, err // Return original string if marshaling fails
+		return jsonStr, err
 	}
 
 	return string(normalized), nil
 }
 
 // updateTerraformFromAPI updates Terraform framework types from simple Go types (JSON response)
-// This handles string -> types.String, int64 -> types.Int64, etc.
 func updateTerraformFromAPI(dst interface{}, src map[string]interface{}) {
 	dstValue := reflect.ValueOf(dst)
 	if dstValue.Kind() != reflect.Ptr || dstValue.IsNil() {
@@ -255,23 +229,18 @@ func updateTerraformFromAPI(dst interface{}, src map[string]interface{}) {
 		field := dstType.Field(i)
 		fieldValue := dstValue.Field(i)
 
-		// Skip unexported fields
 		if !fieldValue.CanSet() {
 			continue
 		}
 
-		// Get JSON tag for field name
 		jsonTag := field.Tag.Get("json")
 		if jsonTag == "" || jsonTag == "-" {
-			// Use tfsdk tag if no json tag
 			jsonTag = field.Tag.Get("tfsdk")
 		}
 		if jsonTag == "" {
-			// Use field name if no tags
 			jsonTag = field.Name
 		}
 
-		// Remove omitempty and other options from tag
 		if commaIdx := len(jsonTag); commaIdx > 0 {
 			for j, char := range jsonTag {
 				if char == ',' {
@@ -282,24 +251,21 @@ func updateTerraformFromAPI(dst interface{}, src map[string]interface{}) {
 			jsonTag = jsonTag[:commaIdx]
 		}
 
-		// Get the value from the source map
 		apiValue, exists := src[jsonTag]
 		if !exists {
 			continue
 		}
 
-		// Convert based on the destination field type
 		switch fieldValue.Type() {
 		case reflect.TypeOf(types.String{}):
 			if apiValue == nil {
 				fieldValue.Set(reflect.ValueOf(types.StringNull()))
 			} else if str, ok := apiValue.(string); ok {
-				// Special handling for filter_expression_json field - normalize JSON
+				// Normalize JSON for filter_expression_json field
 				if jsonTag == "filter_expression_json" {
 					if normalizedStr, err := normalizeJSON(str); err == nil {
 						fieldValue.Set(reflect.ValueOf(types.StringValue(normalizedStr)))
 					} else {
-						// If normalization fails, use the original string
 						fieldValue.Set(reflect.ValueOf(types.StringValue(str)))
 					}
 				} else {
@@ -311,7 +277,6 @@ func updateTerraformFromAPI(dst interface{}, src map[string]interface{}) {
 			if apiValue == nil {
 				fieldValue.Set(reflect.ValueOf(types.Int64Null()))
 			} else {
-				// Handle both int64 and float64 (JSON numbers)
 				switch v := apiValue.(type) {
 				case int64:
 					fieldValue.Set(reflect.ValueOf(types.Int64Value(v)))
@@ -338,7 +303,6 @@ func updateTerraformFromAPI(dst interface{}, src map[string]interface{}) {
 			if apiValue == nil {
 				fieldValue.Set(reflect.ValueOf(types.NumberNull()))
 			} else {
-				// Handle both int64 and float64 (JSON numbers)
 				switch v := apiValue.(type) {
 				case int64:
 					fieldValue.Set(reflect.ValueOf(types.NumberValue(big.NewFloat(float64(v)))))
@@ -352,7 +316,6 @@ func updateTerraformFromAPI(dst interface{}, src map[string]interface{}) {
 	}
 }
 
-// VersionResponse represents the API response when creating a version
 type VersionResponse struct {
 	Id               string `json:"id"`
 	CreatedAt        string `json:"created_at"`
@@ -360,34 +323,25 @@ type VersionResponse struct {
 	UsageGroupSetId  string `json:"usage_group_set_id"`
 }
 
-// APIClient provides high-level methods for common API operations
 type APIClient struct {
 	httpClient *HTTPClient
-	// versionID stores the version ID for the current apply operation
-	// This ensures all resources in the same apply use the same version
+	// Ensures all resources in the same apply use the same version
 	versionID string
-	// versionOnce ensures version creation happens exactly once per apply
-	// sync.Once provides all necessary synchronization guarantees
 	versionOnce sync.Once
-	// versionError stores any error from version creation
 	versionError error
 }
 
-// NewAPIClient creates a new API client with the shared HTTP client
 func NewAPIClient(apiKey, organizationId, baseURL string) *APIClient {
 	return &APIClient{
 		httpClient: NewHTTPClient(apiKey, organizationId, baseURL),
 	}
 }
 
-// doJSONRequest is a high-level method that handles JSON requests and responses
-// Now handles Terraform framework types automatically
+// doJSONRequest handles JSON requests and responses
 func (c *APIClient) doJSONRequest(ctx context.Context, method, endpoint string, requestBody interface{}, responseBody interface{}) diag.Diagnostics {
 	var body io.Reader
 
-	// Marshal request body if provided, converting Terraform types first
 	if requestBody != nil {
-		// Convert Terraform types to simple types for JSON marshaling
 		convertedRequest := convertTerraformToAPI(requestBody)
 
 		jsonData, err := json.Marshal(convertedRequest)
@@ -397,14 +351,12 @@ func (c *APIClient) doJSONRequest(ctx context.Context, method, endpoint string, 
 		body = bytes.NewBuffer(jsonData)
 	}
 
-	// Make the request
 	resp, err := c.httpClient.makeRequest(ctx, method, endpoint, body)
 	if err != nil {
 		return handleHTTPError(fmt.Sprintf("%s %s", method, endpoint), err)
 	}
 	defer resp.Body.Close()
 
-	// Read response body
 	bodyStr, err := readResponseBody(resp)
 	if err != nil {
 		return diag.Diagnostics{
@@ -412,22 +364,16 @@ func (c *APIClient) doJSONRequest(ctx context.Context, method, endpoint string, 
 		}
 	}
 
-	// Handle different status codes
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated:
-		// Success - parse response if responseBody is provided
 		if responseBody != nil && len(bodyStr) > 0 {
-			// Check if responseBody is a regular struct (not containing Terraform types)
 			responseValue := reflect.ValueOf(responseBody)
 			if responseValue.Kind() == reflect.Ptr && responseValue.Elem().Kind() == reflect.Struct {
 				responseType := responseValue.Elem().Type()
-				// Check if it's a regular struct (like VersionResponse) by checking for json tags
-				// and absence of Terraform framework types
 				isRegularStruct := false
 				for i := 0; i < responseType.NumField(); i++ {
 					field := responseType.Field(i)
 					if _, hasJSON := field.Tag.Lookup("json"); hasJSON {
-						// Check if field is a basic Go type (not Terraform framework type)
 						if field.Type.PkgPath() == "" || !strings.Contains(field.Type.String(), "types.") {
 							isRegularStruct = true
 							break
@@ -436,17 +382,14 @@ func (c *APIClient) doJSONRequest(ctx context.Context, method, endpoint string, 
 				}
 				
 				if isRegularStruct {
-					// For regular struct types, unmarshal directly
 					if err := json.Unmarshal([]byte(bodyStr), responseBody); err != nil {
 						return handleJSONError("unmarshal response", err)
 					}
 				} else {
-					// For Terraform models, unmarshal to map first
 					var apiResponse map[string]interface{}
 					if err := json.Unmarshal([]byte(bodyStr), &apiResponse); err != nil {
 						return handleJSONError("unmarshal response", err)
 					}
-					// Update the Terraform model from the API response
 					updateTerraformFromAPI(responseBody, apiResponse)
 				}
 			}
@@ -454,58 +397,45 @@ func (c *APIClient) doJSONRequest(ctx context.Context, method, endpoint string, 
 		return nil
 
 	case http.StatusNotFound:
-		// Resource not found - return a warning
 		return diag.Diagnostics{
 			diag.NewWarningDiagnostic("Resource Not Found", fmt.Sprintf("Resource not found at %s", endpoint)),
 		}
 
 	case http.StatusNoContent:
-		// Success but no content (common for DELETE operations)
 		return nil
 
 	default:
-		// Any other status code is an error
 		return handleResponseError(fmt.Sprintf("%s %s", method, endpoint), resp.StatusCode, bodyStr)
 	}
 }
 
-// Get performs a GET request and unmarshals the response
 func (c *APIClient) Get(ctx context.Context, endpoint string, responseBody interface{}) diag.Diagnostics {
 	return c.doJSONRequest(ctx, "GET", endpoint, nil, responseBody)
 }
 
-// Post performs a POST request with a JSON body and unmarshals the response
 func (c *APIClient) Post(ctx context.Context, endpoint string, requestBody interface{}, responseBody interface{}) diag.Diagnostics {
 	return c.doJSONRequest(ctx, "POST", endpoint, requestBody, responseBody)
 }
 
-// Put performs a PUT request with a JSON body and unmarshals the response
 func (c *APIClient) Put(ctx context.Context, endpoint string, requestBody interface{}, responseBody interface{}) diag.Diagnostics {
 	return c.doJSONRequest(ctx, "PUT", endpoint, requestBody, responseBody)
 }
 
-// Delete performs a DELETE request
 func (c *APIClient) Delete(ctx context.Context, endpoint string) diag.Diagnostics {
 	return c.doJSONRequest(ctx, "DELETE", endpoint, nil, nil)
 }
 
-// GetOrganizationId returns the organization ID configured for this client
 func (c *APIClient) GetOrganizationId() string {
 	return c.httpClient.organizationId
 }
 
 // GetOrCreateVersion creates a new version for the usage group set if one hasn't been created yet
 // for the current apply operation. Returns the version ID.
-// This uses sync.Once to ensure thread-safe creation even with concurrent resource operations.
 func (c *APIClient) GetOrCreateVersion(ctx context.Context, usageGroupSetId string) (string, diag.Diagnostics) {
-	// sync.Once ensures this runs exactly once, even with concurrent calls
-	// It also provides memory synchronization guarantees for the results
 	c.versionOnce.Do(func() {
-		// Create a new version
 		orgId := c.GetOrganizationId()
 		endpoint := fmt.Sprintf("/api/%s/usage-group-sets/%s/versions", orgId, usageGroupSetId)
 
-		// Create request body (empty for now, can be extended later)
 		versionRequest := map[string]interface{}{}
 
 		var versionResponse VersionResponse
@@ -516,7 +446,6 @@ func (c *APIClient) GetOrCreateVersion(ctx context.Context, usageGroupSetId stri
 			return
 		}
 		
-		// Validate we got a version ID
 		if versionResponse.Id == "" {
 			c.versionError = fmt.Errorf("API returned empty version ID")
 			return

--- a/internal/api.go
+++ b/internal/api.go
@@ -30,7 +30,13 @@ type HTTPClient struct {
 func NewHTTPClient(apiKey, organizationId, baseURL string) *HTTPClient {
 	return &HTTPClient{
 		client: &http.Client{
-			Timeout: 30 * time.Second, // 30 second timeout is reasonable for most API calls
+			Transport: &http.Transport{
+				MaxConnsPerHost:     12,  // Allow 12 concurrent connections per host (slightly above Terraform's default parallelism of 10)
+				MaxIdleConns:        100, // Maximum idle connections across all hosts
+				MaxIdleConnsPerHost: 12,  // Maximum idle connections per host
+				IdleConnTimeout:     90 * time.Second,
+			},
+			Timeout: 90 * time.Second,
 		},
 		baseURL:        baseURL,
 		apiKey:         apiKey,

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -14,14 +14,12 @@ import (
 
 var _ provider.Provider = (*selectProvider)(nil)
 
-// ProviderModel describes the provider data model.
 type ProviderModel struct {
 	ApiKey         types.String `tfsdk:"api_key"`
 	OrganizationId types.String `tfsdk:"organization_id"`
 	ApiURL         types.String `tfsdk:"select_api_url"`
 }
 
-// ProviderData contains the configured API client for use by resources and data sources
 type ProviderData struct {
 	Client *APIClient
 }
@@ -62,7 +60,6 @@ func (p *selectProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		return
 	}
 
-	// Validate that api_key is provided
 	if config.ApiKey.IsNull() || config.ApiKey.IsUnknown() {
 		resp.Diagnostics.AddError(
 			"Missing API Key",
@@ -80,7 +77,6 @@ func (p *selectProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		return
 	}
 
-	// Validate that organization_id is provided
 	if config.OrganizationId.IsNull() || config.OrganizationId.IsUnknown() {
 		resp.Diagnostics.AddError(
 			"Missing Organization ID",
@@ -103,10 +99,8 @@ func (p *selectProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		apiURL = "https://api.select.dev"
 	}
 
-	// Create the API client with both API key and organization ID
 	client := NewAPIClient(apiKey, organizationId, apiURL)
 
-	// Store the client in ProviderData so resources can access it
 	providerData := &ProviderData{
 		Client: client,
 	}

--- a/internal/usage_group_resource.go
+++ b/internal/usage_group_resource.go
@@ -27,7 +27,6 @@ type usageGroupResource struct {
 }
 
 func (r *usageGroupResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
 	if req.ProviderData == nil {
 		return
 	}
@@ -49,7 +48,6 @@ func (r *usageGroupResource) Metadata(ctx context.Context, req resource.Metadata
 }
 
 func (r *usageGroupResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	// Use the code-generated schema as base and override usage_group_set_id to be required
 	baseSchema := resource_usage_group.UsageGroupResourceSchema(ctx)
 
 	resp.Schema = baseSchema
@@ -91,30 +89,27 @@ func (r *usageGroupResource) Update(ctx context.Context, req resource.UpdateRequ
 	var plan resource_usage_group.UsageGroupModel
 	var state resource_usage_group.UsageGroupModel
 
-	// Get the planned changes
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Get the current state (which contains the ID)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Create the update model by merging plan with state ID and computed fields
 	updateModel := resource_usage_group.UsageGroupModel{
-		Id:                   state.Id,                  // ID from current state
-		Name:                 plan.Name,                 // Updated name from plan
-		Order:                plan.Order,                // Updated order from plan
-		Budget:               plan.Budget,               // Updated budget from plan
-		FilterExpressionJson: plan.FilterExpressionJson, // Updated filter expression from plan
-		OrganizationId:       state.OrganizationId,      // Keep from state
-		UsageGroupSetId:      state.UsageGroupSetId,     // Keep from state
-		UsageGroupSetName:    state.UsageGroupSetName,   // Keep from state
-		CreatedAt:            state.CreatedAt,           // Keep from state
-		UpdatedAt:            state.UpdatedAt,           // Keep from state
+		Id:                   state.Id,
+		Name:                 plan.Name,
+		Order:                plan.Order,
+		Budget:               plan.Budget,
+		FilterExpressionJson: plan.FilterExpressionJson,
+		OrganizationId:       state.OrganizationId,
+		UsageGroupSetId:      state.UsageGroupSetId,
+		UsageGroupSetName:    state.UsageGroupSetName,
+		CreatedAt:            state.CreatedAt,
+		UpdatedAt:            state.UpdatedAt,
 	}
 
 	resp.Diagnostics.Append(updateUsageGroup(ctx, &updateModel, r.client)...)
@@ -137,7 +132,6 @@ func (r *usageGroupResource) Delete(ctx context.Context, req resource.DeleteRequ
 }
 
 func (r *usageGroupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Parse the import ID as "usage_group_set_id/usage_group_id"
 	importID := req.ID
 	parts := strings.Split(importID, "/")
 
@@ -152,20 +146,14 @@ func (r *usageGroupResource) ImportState(ctx context.Context, req resource.Impor
 	usageGroupSetID := parts[0]
 	usageGroupID := parts[1]
 
-	// Set both IDs in the state
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("usage_group_set_id"), usageGroupSetID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), usageGroupID)...)
 }
 
-// createUsageGroup handles the creation of a new usage group
-// Uses the API route: POST /api/{organization_id}/usage-group-sets/{usage_group_set_id}/usage-groups
 func createUsageGroup(ctx context.Context, model *resource_usage_group.UsageGroupModel, client *APIClient) diag.Diagnostics {
-	// Get organization_id from the client (configured at provider level)
 	orgId := client.GetOrganizationId()
 	usageGroupSetId := model.UsageGroupSetId.ValueString()
 
-	// Create or get the version for this apply operation
-	// This ensures all resources in the same apply use the same version
 	_, versionDiags := client.GetOrCreateVersion(ctx, usageGroupSetId)
 	if versionDiags.HasError() {
 		return versionDiags
@@ -180,22 +168,17 @@ func createUsageGroup(ctx context.Context, model *resource_usage_group.UsageGrou
 		}
 	}
 
-	// Create a copy of the model without computed fields for the request body
 	requestModel := resource_usage_group.UsageGroupModel{
 		Name:                 model.Name,
 		Order:                model.Order,
 		Budget:               model.Budget,
 		FilterExpressionJson: model.FilterExpressionJson,
 		UsageGroupSetId:      model.UsageGroupSetId,
-		// Explicitly exclude: Id (computed), OrganizationId (URL path),
-		// CreatedAt, UpdatedAt, UsageGroupSetName (all computed)
 	}
 
-	// Use the API route: POST /api/{organization_id}/usage-group-sets/{usage_group_set_id}/usage-groups
 	endpoint := fmt.Sprintf("/api/%s/usage-group-sets/%s/usage-groups", orgId, usageGroupSetId)
 	diags := client.Post(ctx, endpoint, &requestModel, model)
 
-	// After successful creation, ensure organization_id and usage_group_set_id are set in the response model
 	if !diags.HasError() {
 		model.OrganizationId = types.StringValue(orgId)
 		// After successful creation, ensure organization_id is set in the response model
@@ -207,10 +190,7 @@ func createUsageGroup(ctx context.Context, model *resource_usage_group.UsageGrou
 	return diags
 }
 
-// readUsageGroup handles reading an existing usage group from the API
-// Uses the API route: GET /api/{organization_id}/usage-group-sets/{usage_group_set_id}/usage-groups/{usage_group_id}
 func readUsageGroup(ctx context.Context, model *resource_usage_group.UsageGroupModel, client *APIClient) diag.Diagnostics {
-	// Get organization_id from the client (configured at provider level)
 	orgId := client.GetOrganizationId()
 	usageGroupSetId := model.UsageGroupSetId.ValueString()
 	usageGroupId := model.Id.ValueString()
@@ -233,11 +213,9 @@ func readUsageGroup(ctx context.Context, model *resource_usage_group.UsageGroupM
 		}
 	}
 
-	// Use the API route: GET /api/{organization_id}/usage-group-sets/{usage_group_set_id}/usage-groups/{usage_group_id}
 	endpoint := fmt.Sprintf("/api/%s/usage-group-sets/%s/usage-groups/%s", orgId, usageGroupSetId, usageGroupId)
 	diags := client.Get(ctx, endpoint, model)
 
-	// After successful read, ensure organization_id is set in the response model
 	if !diags.HasError() {
 		model.OrganizationId = types.StringValue(orgId)
 	}
@@ -245,15 +223,10 @@ func readUsageGroup(ctx context.Context, model *resource_usage_group.UsageGroupM
 	return diags
 }
 
-// updateUsageGroup handles the update of an existing usage group
-// Uses the API route: PUT /api/{organization_id}/usage-group-sets/{usage_group_set_id}/usage-groups/{usage_group_id}
 func updateUsageGroup(ctx context.Context, model *resource_usage_group.UsageGroupModel, client *APIClient) diag.Diagnostics {
-	// Get organization_id from the client (configured at provider level)
 	orgId := client.GetOrganizationId()
 	usageGroupSetId := model.UsageGroupSetId.ValueString()
 
-	// Create or get the version for this apply operation
-	// This ensures all resources in the same apply use the same version
 	_, versionDiags := client.GetOrCreateVersion(ctx, usageGroupSetId)
 	if versionDiags.HasError() {
 		return versionDiags
@@ -278,39 +251,29 @@ func updateUsageGroup(ctx context.Context, model *resource_usage_group.UsageGrou
 		}
 	}
 
-	// Create a copy of the model with only fields allowed for updates
 	requestModel := resource_usage_group.UsageGroupModel{
 		Id:                   model.Id,
 		Name:                 model.Name,
 		Order:                model.Order,
 		Budget:               model.Budget,
 		FilterExpressionJson: model.FilterExpressionJson,
-		// Exclude: OrganizationId, UsageGroupSetId (URL path), CreatedAt, UpdatedAt, UsageGroupSetName (computed)
 	}
 
-	// Use the API route: PUT /api/{organization_id}/usage-group-sets/{usage_group_set_id}/usage-groups/{usage_group_id}
 	endpoint := fmt.Sprintf("/api/%s/usage-group-sets/%s/usage-groups/%s", orgId, usageGroupSetId, usageGroupId)
 	diags := client.Put(ctx, endpoint, &requestModel, model)
 
-	// After successful update, ensure organization_id is set in the response model
 	if !diags.HasError() {
 		model.OrganizationId = types.StringValue(orgId)
-		// UsageGroupSetId is already set in the model, no need to reassign
 	}
 
 	return diags
 }
 
-// deleteUsageGroup handles the deletion of a usage group
-// Uses the API route: DELETE /api/{organization_id}/usage-group-sets/{usage_group_set_id}/usage-groups/{usage_group_id}
 func deleteUsageGroup(ctx context.Context, model *resource_usage_group.UsageGroupModel, client *APIClient) diag.Diagnostics {
-	// Get organization_id from the client (configured at provider level)
 	orgId := client.GetOrganizationId()
 	usageGroupSetId := model.UsageGroupSetId.ValueString()
 	usageGroupId := model.Id.ValueString()
 
-	// Create or get the version for this apply operation
-	// This ensures even destroy operations create a version
 	_, versionDiags := client.GetOrCreateVersion(ctx, usageGroupSetId)
 	if versionDiags.HasError() {
 		return versionDiags
@@ -334,7 +297,6 @@ func deleteUsageGroup(ctx context.Context, model *resource_usage_group.UsageGrou
 		}
 	}
 
-	// Use the API route: DELETE /api/{organization_id}/usage-group-sets/{usage_group_set_id}/usage-groups/{usage_group_id}
 	endpoint := fmt.Sprintf("/api/%s/usage-group-sets/%s/usage-groups/%s", orgId, usageGroupSetId, usageGroupId)
 	return client.Delete(ctx, endpoint)
 }

--- a/internal/usage_group_set_resource.go
+++ b/internal/usage_group_set_resource.go
@@ -26,7 +26,6 @@ type usageGroupSetResource struct {
 }
 
 func (r *usageGroupSetResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
 	if req.ProviderData == nil {
 		return
 	}
@@ -48,7 +47,6 @@ func (r *usageGroupSetResource) Metadata(ctx context.Context, req resource.Metad
 }
 
 func (r *usageGroupSetResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	// Use the code-generated schema
 	resp.Schema = resource_usage_group_set.UsageGroupSetResourceSchema(ctx)
 }
 
@@ -88,26 +86,23 @@ func (r *usageGroupSetResource) Update(ctx context.Context, req resource.UpdateR
 	var plan resource_usage_group_set.UsageGroupSetModel
 	var state resource_usage_group_set.UsageGroupSetModel
 
-	// Get the planned changes
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Get the current state (which contains the ID)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Create the update model by merging plan with state ID
 	updateModel := resource_usage_group_set.UsageGroupSetModel{
-		Id:                        state.Id,                       // ID from current state
-		Name:                      plan.Name,                      // Updated name from plan
-		Order:                     plan.Order,                     // Updated order from plan
-		OrganizationId:            state.OrganizationId,           // Keep from state
-		SnowflakeAccountUuid:      plan.SnowflakeAccountUuid,      // Updated value from plan
-		SnowflakeOrganizationName: plan.SnowflakeOrganizationName, // Updated value from plan
+		Id:                        state.Id,
+		Name:                      plan.Name,
+		Order:                     plan.Order,
+		OrganizationId:            state.OrganizationId,
+		SnowflakeAccountUuid:      plan.SnowflakeAccountUuid,
+		SnowflakeOrganizationName: plan.SnowflakeOrganizationName,
 	}
 
 	resp.Diagnostics.Append(updateUsageGroupSet(ctx, &updateModel, r.client)...)
@@ -130,34 +125,22 @@ func (r *usageGroupSetResource) Delete(ctx context.Context, req resource.DeleteR
 }
 
 func (r *usageGroupSetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Retrieve import ID and save to id attribute
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-// createUsageGroupSet handles the creation of a new usage group set
-// Uses the correct API route with organization_id path parameter
 func createUsageGroupSet(ctx context.Context, model *resource_usage_group_set.UsageGroupSetModel, client *APIClient) diag.Diagnostics {
-	// Get organization_id from the client (configured at provider level)
 	orgId := client.GetOrganizationId()
 	
-	// Note: Version creation happens at the usage group level
-	// The usage group set just provides the container
-
-	// Create a copy of the model without organization_id for the request body
-	// (organization_id goes in the URL path only, not the JSON payload)
 	requestModel := resource_usage_group_set.UsageGroupSetModel{
 		Name:                      model.Name,
 		Order:                     model.Order,
 		SnowflakeAccountUuid:      model.SnowflakeAccountUuid,
 		SnowflakeOrganizationName: model.SnowflakeOrganizationName,
-		// Explicitly exclude: Id (computed) and OrganizationId (URL path only)
 	}
 
-	// Use the correct API route: POST /api/{organization_id}/usage-group-sets
 	endpoint := fmt.Sprintf("/api/%s/usage-group-sets", orgId)
 	diags := client.Post(ctx, endpoint, &requestModel, model)
 
-	// After successful creation, set the organization_id in the response model
 	if !diags.HasError() {
 		model.OrganizationId = types.StringValue(orgId)
 	}
@@ -165,10 +148,7 @@ func createUsageGroupSet(ctx context.Context, model *resource_usage_group_set.Us
 	return diags
 }
 
-// readUsageGroupSet handles reading an existing usage group set from the API
-// Uses the correct API route with organization_id and usage_group_set_id path parameters
 func readUsageGroupSet(ctx context.Context, model *resource_usage_group_set.UsageGroupSetModel, client *APIClient) diag.Diagnostics {
-	// Get organization_id from the client (configured at provider level)
 	orgId := client.GetOrganizationId()
 	usageGroupSetId := model.Id.ValueString()
 
@@ -181,11 +161,9 @@ func readUsageGroupSet(ctx context.Context, model *resource_usage_group_set.Usag
 		}
 	}
 
-	// Use the correct API route: GET /api/{organization_id}/usage-group-sets/{usage_group_set_id}
 	endpoint := fmt.Sprintf("/api/%s/usage-group-sets/%s", orgId, usageGroupSetId)
 	diags := client.Get(ctx, endpoint, model)
 
-	// After successful read, ensure organization_id is set in the response model
 	if !diags.HasError() {
 		model.OrganizationId = types.StringValue(orgId)
 	}
@@ -193,15 +171,10 @@ func readUsageGroupSet(ctx context.Context, model *resource_usage_group_set.Usag
 	return diags
 }
 
-// updateUsageGroupSet handles the update of an existing usage group set
-// Uses the correct API route with organization_id and usage_group_set_id path parameters
 func updateUsageGroupSet(ctx context.Context, model *resource_usage_group_set.UsageGroupSetModel, client *APIClient) diag.Diagnostics {
-	// Get organization_id from the client (configured at provider level)
 	orgId := client.GetOrganizationId()
 	usageGroupSetId := model.Id.ValueString()
 	
-	// Create or get the version for this apply operation
-	// This ensures all resources in the same apply use the same version
 	_, versionDiags := client.GetOrCreateVersion(ctx, usageGroupSetId)
 	if versionDiags.HasError() {
 		return versionDiags
@@ -217,19 +190,16 @@ func updateUsageGroupSet(ctx context.Context, model *resource_usage_group_set.Us
 	}
 
 	// Create a copy of the model with only fields allowed in UsageGroupSetUpdate schema
-	// According to OpenAPI spec: only id, name, and order are allowed for updates
+	// Only id, name, and order are allowed for updates per OpenAPI spec
 	requestModel := resource_usage_group_set.UsageGroupSetModel{
 		Id:    model.Id,
 		Name:  model.Name,
 		Order: model.Order,
-		// Exclude: OrganizationId (URL path only), SnowflakeAccountUuid, SnowflakeOrganizationName (not allowed in update)
 	}
 
-	// Use the correct API route: PUT /api/{organization_id}/usage-group-sets/{usage_group_set_id}
 	endpoint := fmt.Sprintf("/api/%s/usage-group-sets/%s", orgId, usageGroupSetId)
 	diags := client.Put(ctx, endpoint, &requestModel, model)
 
-	// After successful update, ensure organization_id is set in the response model
 	if !diags.HasError() {
 		model.OrganizationId = types.StringValue(orgId)
 	}
@@ -237,10 +207,7 @@ func updateUsageGroupSet(ctx context.Context, model *resource_usage_group_set.Us
 	return diags
 }
 
-// deleteUsageGroupSet handles the deletion of a usage group set
-// Uses the correct API route with organization_id and usage_group_set_id path parameters
 func deleteUsageGroupSet(ctx context.Context, model *resource_usage_group_set.UsageGroupSetModel, client *APIClient) diag.Diagnostics {
-	// Get organization_id from the client (configured at provider level)
 	orgId := client.GetOrganizationId()
 	usageGroupSetId := model.Id.ValueString()
 
@@ -253,7 +220,6 @@ func deleteUsageGroupSet(ctx context.Context, model *resource_usage_group_set.Us
 		}
 	}
 
-	// Use the correct API route: DELETE /api/{organization_id}/usage-group-sets/{usage_group_set_id}
 	endpoint := fmt.Sprintf("/api/%s/usage-group-sets/%s", orgId, usageGroupSetId)
 	return client.Delete(ctx, endpoint)
 }

--- a/internal/usage_group_set_resource.go
+++ b/internal/usage_group_set_resource.go
@@ -139,6 +139,9 @@ func (r *usageGroupSetResource) ImportState(ctx context.Context, req resource.Im
 func createUsageGroupSet(ctx context.Context, model *resource_usage_group_set.UsageGroupSetModel, client *APIClient) diag.Diagnostics {
 	// Get organization_id from the client (configured at provider level)
 	orgId := client.GetOrganizationId()
+	
+	// Note: Version creation happens at the usage group level
+	// The usage group set just provides the container
 
 	// Create a copy of the model without organization_id for the request body
 	// (organization_id goes in the URL path only, not the JSON payload)
@@ -196,6 +199,13 @@ func updateUsageGroupSet(ctx context.Context, model *resource_usage_group_set.Us
 	// Get organization_id from the client (configured at provider level)
 	orgId := client.GetOrganizationId()
 	usageGroupSetId := model.Id.ValueString()
+	
+	// Create or get the version for this apply operation
+	// This ensures all resources in the same apply use the same version
+	_, versionDiags := client.GetOrCreateVersion(ctx, usageGroupSetId)
+	if versionDiags.HasError() {
+		return versionDiags
+	}
 
 	if usageGroupSetId == "" {
 		return diag.Diagnostics{


### PR DESCRIPTION
This PR uses the new endpoint to create a new usage group version for all changes in a single terraform apply

It alse cleans up comments that explained what code did or referenced old code that had been removed
