### PR TITLE
Deprecate Snowflake entity scoped usage groups

### DIFF
--- a/examples/resources/select_usage_group_set/resource.tf
+++ b/examples/resources/select_usage_group_set/resource.tf
@@ -1,5 +1,4 @@
 resource "select_usage_group_set" "production" {
-  name                   = "Production Workloads"
-  order                  = 1
-  snowflake_account_uuid = "12345678-1234-1234-1234-123456789012"
+  name  = "Production Workloads"
+  order = 1
 } 

--- a/generator_config.yml
+++ b/generator_config.yml
@@ -18,6 +18,9 @@ resources:
       path: /api/{organization_id}/usage-group-sets/{usage_group_set_id}
       method: DELETE
     schema:
+      ignores:
+        - snowflake_account_uuid
+        - snowflake_organization_name
       attributes:
         overrides:
           name:

--- a/internal/usage_group_set_resource.go
+++ b/internal/usage_group_set_resource.go
@@ -101,8 +101,7 @@ func (r *usageGroupSetResource) Update(ctx context.Context, req resource.UpdateR
 		Name:           plan.Name,
 		Order:          plan.Order,
 		OrganizationId: state.OrganizationId,
-		// Scope fields (SnowflakeAccountUuid, SnowflakeOrganizationName, TeamId) are immutable
-		// per the API spec and cannot be changed after creation
+		// TeamId is immutable per the API spec and cannot be changed after creation
 	}
 
 	resp.Diagnostics.Append(updateUsageGroupSet(ctx, &updateModel, r.client)...)
@@ -132,11 +131,9 @@ func createUsageGroupSet(ctx context.Context, model *resource_usage_group_set.Us
 	orgId := client.GetOrganizationId()
 	
 	requestModel := resource_usage_group_set.UsageGroupSetModel{
-		Name:                      model.Name,
-		Order:                     model.Order,
-		SnowflakeAccountUuid:      model.SnowflakeAccountUuid,
-		SnowflakeOrganizationName: model.SnowflakeOrganizationName,
-		TeamId:                    model.TeamId,
+		Name:   model.Name,
+		Order:  model.Order,
+		TeamId: model.TeamId,
 	}
 
 	endpoint := fmt.Sprintf("/api/%s/usage-group-sets", orgId)

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -35,22 +35,10 @@ variable "usage_group_set_order" {
   default     = 1
 }
 
-variable "test_snowflake_account_uuid" {
-  description = "Test Snowflake account UUID"
-  type        = string
-  default     = "12345678-1234-1234-1234-123456789012"
-}
-
-variable "test_snowflake_org_name" {
-  description = "Test Snowflake organization name"
-  type        = string
-  default     = "test-snowflake-org"
-}
-
 variable "test_team_id" {
   description = "Test team UUID"
   type        = string
-  default     = "01fee6c9-d575-43e1-95d1-16de9e8bed18"
+  default     = "2f0899e2-2746-4300-887c-524e64b5a138"
 }
 
 variable "usage_group_name" {
@@ -92,11 +80,10 @@ provider "select" {
   select_api_url = "http://localhost:8000"
 }
 
-# Usage group set with Snowflake account
-resource "select_usage_group_set" "test_account" {
-  name                   = var.usage_group_set_name
-  order                  = var.usage_group_set_order
-  snowflake_account_uuid = var.test_snowflake_account_uuid
+# Usage group set with SELECT organization scope
+resource "select_usage_group_set" "test_org" {
+  name  = var.usage_group_set_name
+  order = var.usage_group_set_order
 }
 
 # Usage group set with team scope
@@ -118,7 +105,7 @@ resource "select_usage_group" "test_basic" {
   name                   = var.usage_group_name
   order                  = var.usage_group_order
   budget                 = var.usage_group_budget
-  usage_group_set_id     = select_usage_group_set.test_account.id
+  usage_group_set_id     = select_usage_group_set.test_org.id
   filter_expression_json = var.simple_filter_expression_json
 }
 
@@ -127,7 +114,7 @@ resource "select_usage_group" "test_with_budget" {
   name                   = "${var.usage_group_name}-with-budget"
   order                  = var.usage_group_order + 1
   budget                 = 100.0
-  usage_group_set_id     = select_usage_group_set.test_account.id
+  usage_group_set_id     = select_usage_group_set.test_org.id
   filter_expression_json = var.simple_filter_expression_json
 }
 
@@ -136,17 +123,17 @@ resource "select_usage_group" "test_complex_filter" {
   name                   = "${var.usage_group_name}-complex"
   order                  = var.usage_group_order + 2
   budget                 = null
-  usage_group_set_id     = select_usage_group_set.test_account.id
+  usage_group_set_id     = select_usage_group_set.test_org.id
   filter_expression_json = var.complex_filter_expression_json
 }
 
 # Outputs for verification
 output "usage_group_set_id" {
-  value = select_usage_group_set.test_account.id
+  value = select_usage_group_set.test_org.id
 }
 
 output "usage_group_set_name" {
-  value = select_usage_group_set.test_account.name
+  value = select_usage_group_set.test_org.name
 }
 
 output "basic_usage_group_id" {

--- a/tests/provider.tftest.hcl
+++ b/tests/provider.tftest.hcl
@@ -7,8 +7,7 @@ variables {
   # and must correlate to an APIKey in the Db of whatever instance you're testing against
   # TF_VAR_select_api_key
   # TF_VAR_select_organization_id
-  test_snowflake_account_uuid = "scwxhob-ad38017"
-  test_team_id                = "01fee6c9-d575-43e1-95d1-16de9e8bed18"
+  test_team_id = "2f0899e2-2746-4300-887c-524e64b5a138"
   usage_group_set_name        = "terraform-test-set"
   usage_group_set_order       = 1
   usage_group_name            = "terraform-test-group"
@@ -21,22 +20,17 @@ run "create_usage_group_set" {
   command = apply
 
   assert {
-    condition     = select_usage_group_set.test_account.name == var.usage_group_set_name
+    condition     = select_usage_group_set.test_org.name == var.usage_group_set_name
     error_message = "Usage group set name should match expected value"
   }
 
   assert {
-    condition     = select_usage_group_set.test_account.order == var.usage_group_set_order
+    condition     = select_usage_group_set.test_org.order == var.usage_group_set_order
     error_message = "Usage group set order should match expected value"
   }
 
   assert {
-    condition     = select_usage_group_set.test_account.snowflake_account_uuid == var.test_snowflake_account_uuid
-    error_message = "Snowflake account UUID should match expected value"
-  }
-
-  assert {
-    condition     = select_usage_group_set.test_account.id != null
+    condition     = select_usage_group_set.test_org.id != null
     error_message = "Usage group set ID should be set after creation"
   }
 }
@@ -53,11 +47,6 @@ run "create_team_scoped_usage_group_set" {
   assert {
     condition     = select_usage_group_set.test_team.team_id == var.test_team_id
     error_message = "Team ID should match expected value"
-  }
-
-  assert {
-    condition     = select_usage_group_set.test_team.snowflake_account_uuid == null
-    error_message = "Snowflake account UUID should be null for team-scoped set"
   }
 
   assert {
@@ -81,11 +70,6 @@ run "create_select_org_scoped_usage_group_set" {
   }
 
   assert {
-    condition     = select_usage_group_set.test_select_org.snowflake_account_uuid == null
-    error_message = "Snowflake account UUID should be null for SELECT org-scoped set"
-  }
-
-  assert {
     condition     = select_usage_group_set.test_select_org.id != null
     error_message = "SELECT org-scoped usage group set ID should be set after creation"
   }
@@ -106,7 +90,7 @@ run "create_usage_groups" {
   }
 
   assert {
-    condition     = select_usage_group.test_basic.usage_group_set_id == select_usage_group_set.test_account.id
+    condition     = select_usage_group.test_basic.usage_group_set_id == select_usage_group_set.test_org.id
     error_message = "Usage group should belong to the correct usage group set"
   }
 
@@ -136,7 +120,7 @@ run "verify_usage_group_with_budget" {
   }
 
   assert {
-    condition     = select_usage_group.test_with_budget.usage_group_set_id == select_usage_group_set.test_account.id
+    condition     = select_usage_group.test_with_budget.usage_group_set_id == select_usage_group_set.test_org.id
     error_message = "Usage group with budget should belong to correct set"
   }
 }
@@ -202,18 +186,18 @@ run "update_usage_group_set" {
   }
 
   assert {
-    condition     = select_usage_group_set.test_account.name == "terraform-test-set-updated"
+    condition     = select_usage_group_set.test_org.name == "terraform-test-set-updated"
     error_message = "Usage group set name should be updated"
   }
 
   assert {
-    condition     = select_usage_group_set.test_account.order == 5
+    condition     = select_usage_group_set.test_org.order == 5
     error_message = "Usage group set order should be updated"
   }
 
   # Ensure ID stability during updates
   assert {
-    condition     = select_usage_group_set.test_account.id != null
+    condition     = select_usage_group_set.test_org.id != null
     error_message = "Usage group set ID should remain stable during updates"
   }
 }


### PR DESCRIPTION
We have changed usage groups to no longer be scoped to a snowflake organization or a snowflake account, they are instead either scoped to your SELECT organization or a specific SELECT team. 

These changes remove `snowflake_account_uuid` and `snowflake_organization_name` from the usage group set block